### PR TITLE
Add input polling and preliminary row shifting

### DIFF
--- a/board.c
+++ b/board.c
@@ -1,5 +1,6 @@
 
 #include <string.h>
+#include <stdlib.h>
 #include "board.h"
 
 static char *g_board;
@@ -9,8 +10,6 @@ void board_create(int rows, int cols) {
   len = rows * cols;
   g_board = malloc(sizeof(char) * len);
   memset(g_board, 0, sizeof(char) * len);
-  
-  return g_board;
 }
 
 void board_free() {

--- a/board.c
+++ b/board.c
@@ -50,3 +50,31 @@ int board_collides(tetro *t) {
 
   return retVal;
 }
+
+static void shiftRowsDown(int rows, int cols, int pos) {
+  for (int i = (pos + cols - 1); i >= cols; i--) {
+    g_board[i] = g_board[i - cols];
+  }
+}
+
+void board_checkRowShift(int rows, int cols) {
+  for (int i = (rows - 1); i > 0; i--) {
+    int pos = i * cols;
+    int streak = 0;
+    for (int j = pos; j < (pos + cols); j++) {
+      if (g_board[j] && streak == 0) {
+        streak++;
+      } else if (g_board[j] && streak > 0) {
+        streak++;
+      } else if (!g_board[j] && streak == 0) {
+        continue;
+      } else if (!g_board[j] && streak > 0) {
+        break;
+      }
+    }
+
+    if (streak >= 5) {
+      shiftRowsDown(rows, cols, pos);
+    }
+  }
+}

--- a/board.h
+++ b/board.h
@@ -9,3 +9,4 @@ char *board_get();
 void board_addToBoard(tetro *t, int screenCols);
 int board_collides(tetro *t);
 int board_len();
+void board_checkRowShift();

--- a/board.h
+++ b/board.h
@@ -8,3 +8,4 @@ char *board_get();
 
 void board_addToBoard(tetro *t, int screenCols);
 int board_collides(tetro *t);
+int board_len();

--- a/kilo.c
+++ b/kilo.c
@@ -501,6 +501,8 @@ void updateGame() {
     g_tetro->update(g_tetro, E.screenCols);
   }
 
+  board_checkRowShift(E.screenRows, E.screenCols);
+
   frame++;
 }
 

--- a/tetro.c
+++ b/tetro.c
@@ -148,7 +148,7 @@ void tetro_lRotate(tetro *t, int screenWidth) {
   { DOWN, 0, 400, {0, 400, 0, 0}, NULL }
 
 tetro *tetro_create() {
-  struct timeval stop, start;
+  struct timeval start;
   gettimeofday(&start, NULL);
   int type = start.tv_usec % 3 + 1;
 


### PR DESCRIPTION
## :star: What's new in this PR?
- Add input polling that doesn't wait block while waiting for user input.
- Add preliminary row shifting. Since the command line terminal is much wider than a normal tetris game, I check for a streak of 5+ blocks in a row and consider that completed line and shift the rows above down.